### PR TITLE
DjangoRedisChannelLayer

### DIFF
--- a/asgi_redis/__init__.py
+++ b/asgi_redis/__init__.py
@@ -1,4 +1,4 @@
-from .core import RedisChannelLayer, DjangoRedisChannelLayer
+from .core import RedisChannelLayer
 from .local import RedisLocalChannelLayer
 
 __version__ = '0.14.1'

--- a/asgi_redis/__init__.py
+++ b/asgi_redis/__init__.py
@@ -1,5 +1,5 @@
 import pkg_resources
-from .core import RedisChannelLayer
+from .core import RedisChannelLayer, DjangoRedisChannelLayer
 from .local import RedisLocalChannelLayer
 
 __version__ = pkg_resources.require('asgi_redis')[0].version

--- a/asgi_redis/core.py
+++ b/asgi_redis/core.py
@@ -16,6 +16,10 @@ try:
     import txredisapi
 except ImportError:
     pass
+try:
+    from django_redis import get_redis_connection
+except ImportError:
+    pass
 
 from asgiref.base_layer import BaseChannelLayer
 from .twisted_utils import defer
@@ -53,10 +57,7 @@ class RedisChannelLayer(BaseChannelLayer):
         self.ring_divisor = int(math.ceil(4096 / float(self.ring_size)))
         # Create connections ahead of time (they won't call out just yet, but
         # we want to connection-pool them later)
-        self._connection_list = [
-            redis.Redis.from_url(host)
-            for host in self.hosts
-        ]
+        self._connection_list = self._generate_connections()
         # Decide on a unique client prefix to use in ! sections
         # TODO: ensure uniqueness better, e.g. Redis keys with SETNX
         self.client_prefix = "".join(random.choice(string.ascii_letters) for i in range(8))
@@ -77,6 +78,12 @@ class RedisChannelLayer(BaseChannelLayer):
             self.crypter = MultiFernet(sub_fernets)
         else:
             self.crypter = None
+
+    def _generate_connections(self):
+        return [
+            redis.Redis.from_url(host)
+            for host in self.hosts
+        ]
 
     ### ASGI API ###
 
@@ -388,3 +395,7 @@ class RedisChannelLayer(BaseChannelLayer):
     def __str__(self):
         return "%s(hosts=%s)" % (self.__class__.__name__, self.hosts)
 
+
+class DjangoRedisChannelLayer(RedisChannelLayer):
+    def _generate_connections(self):
+            return [get_redis_connection()]

--- a/asgi_redis/core.py
+++ b/asgi_redis/core.py
@@ -16,10 +16,6 @@ try:
     import txredisapi
 except ImportError:
     pass
-try:
-    from django_redis import get_redis_connection
-except ImportError:
-    pass
 
 from asgiref.base_layer import BaseChannelLayer
 from .twisted_utils import defer
@@ -395,8 +391,3 @@ class RedisChannelLayer(BaseChannelLayer):
 
     def __str__(self):
         return "%s(hosts=%s)" % (self.__class__.__name__, self.hosts)
-
-
-class DjangoRedisChannelLayer(RedisChannelLayer):
-    def _generate_connections(self):
-            return [get_redis_connection()]


### PR DESCRIPTION
Hi again,

I'm not sure if these changes actually belong here, but I thought I'd make this PR to open up the discussion.

Essentially, I found that in order to have more control over how many active Redis connections there are, I needed to have a variation of the RedisChannelLayer class that uses the connection from `django-redis`. This way, when I limit the number of connections from `django-redis`, that limit is respected by `asgi_redis`.

Do you think this belongs here? Or perhaps even a standalone package that implements this? I'm not too sure...

Cheers,
Luke