### PR TITLE
Properly catch bad hosts config instead of silently creating bad hosts

### DIFF
--- a/asgi_redis/core.py
+++ b/asgi_redis/core.py
@@ -49,6 +49,11 @@ class RedisChannelLayer(BaseChannelLayer):
         if not hosts:
             hosts = [("localhost", 6379)]
         self.hosts = []
+        
+        if isinstance(hosts, six.string_types):
+            # user accidentally used one host string instead of providing a list of hosts
+            raise ValueError('ASGI Redis hosts must be specified as an iterable list of hosts.')
+                             
         for entry in hosts:
             if isinstance(entry, six.string_types):
                 self.hosts.append(entry)


### PR DESCRIPTION
This caused me almost an hour of headache, as I was trying to find out why every 3rd or 4th django-channels request was silently failing.
It turned out, I had specified a bad config:

```python
CHANNEL_LAYERS = {
    'default': {
        'BACKEND': 'asgi_redis.RedisChannelLayer',
        'CONFIG': {
            'hosts': 'redis://localhost:6379/3',  # instead of ['redis://localhost:6379/3']
        },
        'ROUTING': 'ui.urls.socket_routing',
    },
}
```

The current `core.py` code creates a malformed lists of hosts when it gets this config, which caused many requests to fail as they hit nonexistent redis hosts (but not all requests for some reason...?):
```python
# core.py:52
for entry in hosts:
    if isinstance(entry, six.string_types):
        self.hosts.append(entry)
# self.hosts = ['r', 'e', 'd', 'i', 's', ':', '/', '/', '1', '2', '7', '.', '0', '.', '0', '.', '1', ':', '6', '3', '7', '9', '/', '3']
```

My change just adds a simple check to make sure the user provided a valid config, and raises a `ValueError` if it's not the expected type.  Hopefully it will save someone else hours of tearing their hair out if they make the same mistake.