### PR TITLE
Statistics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.egg-info
 dist/
 build/
+*.pyc

--- a/asgi_redis/core.py
+++ b/asgi_redis/core.py
@@ -290,6 +290,7 @@ class RedisChannelLayer(BaseChannelLayer):
         """
         for connection in self._connection_list:
             self.delprefix(keys=[], args=[self.prefix+"*"], client=connection)
+            self.delprefix(keys=[], args=[self.stats_prefix+"*"], client=connection)
 
     ### Twisted extension ###
 
@@ -352,14 +353,14 @@ class RedisChannelLayer(BaseChannelLayer):
             # 'messages_max_age': 0,
             'channel_full_count': 0,
         }
-        prefix = '{stat_prefix}{global_key}'.fromat(self.stats_prefix, self.global_stats_key)
+        prefix = self.stats_prefix + self.global_stats_key
         for connection in self._connection_list:
             messages_count, channel_full_count = connection.mget(
                 prefix + ':messages_count',
                 prefix + ':channel_full_count',
             )
-            statistics['messages_count'] += messages_count or 0
-            statistics['channel_full_count'] += channel_full_count or 0
+            statistics['messages_count'] += int(messages_count or 0)
+            statistics['channel_full_count'] += int(channel_full_count or 0)
 
         return statistics
 
@@ -380,7 +381,7 @@ class RedisChannelLayer(BaseChannelLayer):
             'messages_max_age': 0,
             'channel_full_count': 0,
         }
-        prefix = '{stat_prefix}{channel}'.fromat(self.stats_prefix, channel)
+        prefix = self.stats_prefix + channel
 
         if "!" in channel or "?" in channel:
             connections = [self.connection(self.consistent_hash(channel))]
@@ -395,8 +396,8 @@ class RedisChannelLayer(BaseChannelLayer):
                 prefix + ':messages_count',
                 prefix + ':channel_full_count',
             )
-            statistics['messages_count'] += messages_count or 0
-            statistics['channel_full_count'] += channel_full_count or 0
+            statistics['messages_count'] += int(messages_count or 0)
+            statistics['channel_full_count'] += int(channel_full_count or 0)
             statistics['messages_pending'] += connection.llen(channel_key)
             oldest_message = connection.lindex(channel_key, 0)
             if oldest_message:

--- a/asgi_redis/core.py
+++ b/asgi_redis/core.py
@@ -348,8 +348,8 @@ class RedisChannelLayer(BaseChannelLayer):
         """
         statistics = {
             'messages_count': 0,
-            'messages_pending': 0,
-            'messages_max_age': 0,
+            # 'messages_pending': 0,  #  not sure how to do this w/o iterating over _all_ channels
+            # 'messages_max_age': 0,
             'channel_full_count': 0,
         }
         prefix = '{stat_prefix}{global_key}'.fromat(self.stats_prefix, self.global_stats_key)

--- a/asgi_redis/core.py
+++ b/asgi_redis/core.py
@@ -358,8 +358,8 @@ class RedisChannelLayer(BaseChannelLayer):
         prefix = self.stats_prefix + self.global_stats_key
         for connection in self._connection_list:
             messages_count, channel_full_count = connection.mget(
-                ':'.join(prefix, self.STAT_MESSAGES_COUNT),
-                ':'.join(prefix, self.STAT_CHANNEL_FULL),
+                ':'.join((prefix, self.STAT_MESSAGES_COUNT)),
+                ':'.join((prefix, self.STAT_CHANNEL_FULL)),
             )
             statistics[self.STAT_MESSAGES_COUNT] += int(messages_count or 0)
             statistics[self.STAT_CHANNEL_FULL] += int(channel_full_count or 0)
@@ -395,11 +395,11 @@ class RedisChannelLayer(BaseChannelLayer):
 
         for connection in connections:
             messages_count, channel_full_count = connection.mget(
-                ':'.join(prefix, self.STAT_MESSAGES_COUNT),
-                ':'.join(prefix, self.STAT_CHANNEL_FULL),
+                ':'.join((prefix, self.STAT_MESSAGES_COUNT)),
+                ':'.join((prefix, self.STAT_CHANNEL_FULL)),
             )
             statistics[self.STAT_MESSAGES_COUNT] += int(messages_count or 0)
-            statistics[self.STAT_CHANNEL_FULL:] += int(channel_full_count or 0)
+            statistics[self.STAT_CHANNEL_FULL] += int(channel_full_count or 0)
             statistics[self.STAT_MESSAGES_PENDING] += connection.llen(channel_key)
             oldest_message = connection.lindex(channel_key, 0)
             if oldest_message:

--- a/asgi_redis/core.py
+++ b/asgi_redis/core.py
@@ -359,7 +359,7 @@ class RedisChannelLayer(BaseChannelLayer):
         for connection in self._connection_list:
             messages_count, channel_full_count = connection.mget(
                 ':'.join(prefix, self.STAT_MESSAGES_COUNT),
-                ':'.join(prefix, self.STAT_CHANNELS_FULL),
+                ':'.join(prefix, self.STAT_CHANNEL_FULL),
             )
             statistics[self.STAT_MESSAGES_COUNT] += int(messages_count or 0)
             statistics[self.STAT_CHANNEL_FULL] += int(channel_full_count or 0)
@@ -399,7 +399,7 @@ class RedisChannelLayer(BaseChannelLayer):
                 ':'.join(prefix, self.STAT_CHANNEL_FULL),
             )
             statistics[self.STAT_MESSAGES_COUNT] += int(messages_count or 0)
-            statistics[self.STAT_CHANNELS_FULL:] += int(channel_full_count or 0)
+            statistics[self.STAT_CHANNEL_FULL:] += int(channel_full_count or 0)
             statistics[self.STAT_MESSAGES_PENDING] += connection.llen(channel_key)
             oldest_message = connection.lindex(channel_key, 0)
             if oldest_message:

--- a/asgi_redis/core.py
+++ b/asgi_redis/core.py
@@ -341,16 +341,15 @@ class RedisChannelLayer(BaseChannelLayer):
         Returns dictionary of statistics across all channels on all shards.
         Return value is a dictionary with following fields:
             * messages_count, the number of messages processed since server start
-            * messages_pending, the current number of messages waiting
-            * messages_max_age, how long the oldest message has been waiting, in seconds
             * channel_full_count, the number of times ChannelFull exception has been risen since server start
 
-        This implementation does not provide calculated per second values
+        This implementation does not provide calculated per second values.
+        Due perfomance concerns, does not provide aggregated messages_pending and messages_max_age,
+        these are only avaliable per channel.
+
         """
         statistics = {
             'messages_count': 0,
-            # 'messages_pending': 0,  #  not sure how to do this w/o iterating over _all_ channels
-            # 'messages_max_age': 0,
             'channel_full_count': 0,
         }
         prefix = self.stats_prefix + self.global_stats_key

--- a/asgi_redis/core.py
+++ b/asgi_redis/core.py
@@ -36,9 +36,12 @@ class RedisChannelLayer(BaseChannelLayer):
     """
 
     blpop_timeout = 5
+    global_statistics_expiry = 86400
+    channel_statistics_expiry = 3600
+    global_stats_key = '#global#' # needs to be invalid as a channel name
 
     def __init__(self, expiry=60, hosts=None, prefix="asgi:", group_expiry=86400, capacity=100, channel_capacity=None,
-                 symmetric_encryption_keys=None):
+                 symmetric_encryption_keys=None, stats_prefix="asgi-meta:"):
         super(RedisChannelLayer, self).__init__(
             expiry=expiry,
             group_expiry=group_expiry,
@@ -74,6 +77,7 @@ class RedisChannelLayer(BaseChannelLayer):
         self.chansend = connection.register_script(self.lua_chansend)
         self.lpopmany = connection.register_script(self.lua_lpopmany)
         self.delprefix = connection.register_script(self.lua_delprefix)
+        self.incrstatcounters = connection.register_script(self.lua_incrstatcounters)
         # See if we can do encryption if they asked
         if symmetric_encryption_keys:
             if isinstance(symmetric_encryption_keys, six.string_types):
@@ -86,6 +90,7 @@ class RedisChannelLayer(BaseChannelLayer):
             self.crypter = MultiFernet(sub_fernets)
         else:
             self.crypter = None
+        self.stats_prefix = stats_prefix
 
     def _generate_connections(self):
         return [
@@ -95,7 +100,7 @@ class RedisChannelLayer(BaseChannelLayer):
 
     ### ASGI API ###
 
-    extensions = ["groups", "flush", "twisted"]
+    extensions = ["groups", "flush", "twisted", "statistics"]
 
     def send(self, channel, message):
         # Typecheck
@@ -119,9 +124,19 @@ class RedisChannelLayer(BaseChannelLayer):
                 args=[self.serialize(message), self.expiry, self.get_capacity(channel)],
                 client=connection,
             )
+            self._incr_statistics_counter(
+                stat_name='messages_count',
+                channel=channel,
+                connection=connection,
+            )
         except redis.exceptions.ResponseError as e:
             # The Lua script handles capacity checking and sends the "full" error back
             if e.args[0] == "full":
+                self._incr_statistics_counter(
+                    stat_name='channel_full_count',
+                    channel=channel,
+                    connection=connection,
+                )
                 raise self.ChannelFull
             elif "unknown command" in e.args[0]:
                 raise UnsupportedRedis(
@@ -317,6 +332,97 @@ class RedisChannelLayer(BaseChannelLayer):
             finally:
                 yield twisted_connection.disconnect()
 
+
+    ### statistics extension ###
+
+    def global_statistics(self):
+        """
+        Returns dictionary of statistics across all channels on all shards.
+        Return value is a dictionary with following fields:
+            * messages_count, the number of messages processed since server start
+            * messages_pending, the current number of messages waiting
+            * messages_max_age, how long the oldest message has been waiting, in seconds
+            * channel_full_count, the number of times ChannelFull exception has been risen since server start
+
+        This implementation does not provide calculated per second values
+        """
+        statistics = {
+            'messages_count': 0,
+            'messages_pending': 0,
+            'messages_max_age': 0,
+            'channel_full_count': 0,
+        }
+        prefix = '{stat_prefix}{global_key}'.fromat(self.stats_prefix, self.global_stats_key)
+        for connection in self._connection_list:
+            messages_count, channel_full_count = connection.mget(
+                prefix + ':messages_count',
+                prefix + ':channel_full_count',
+            )
+            statistics['messages_count'] += messages_count or 0
+            statistics['channel_full_count'] += channel_full_count or 0
+
+        return statistics
+
+    def channel_statistics(self, channel):
+        """
+        Returns dictionary of statistics for specified channel.
+        Return value is a dictionary with following fields:
+            * messages_count, the number of messages processed since server start
+            * messages_pending, the current number of messages waiting
+            * messages_max_age, how long the oldest message has been waiting, in seconds
+            * channel_full_count, the number of times ChannelFull exception has been risen since server start
+
+        This implementation does not provide calculated per second values
+        """
+        statistics = {
+            'messages_count': 0,
+            'messages_pending': 0,
+            'messages_max_age': 0,
+            'channel_full_count': 0,
+        }
+        prefix = '{stat_prefix}{channel}'.fromat(self.stats_prefix, channel)
+
+        if "!" in channel or "?" in channel:
+            connections = [self.connection(self.consistent_hash(channel))]
+        else:
+            # if we don't know where it is, we have to check in all shards
+            connections = self._connection_list
+
+        channel_key = self.prefix + channel
+
+        for connection in connections:
+            messages_count, channel_full_count = connection.mget(
+                prefix + ':messages_count',
+                prefix + ':channel_full_count',
+            )
+            statistics['messages_count'] += messages_count or 0
+            statistics['channel_full_count'] += channel_full_count or 0
+            statistics['messages_pending'] += connection.llen(channel_key)
+            oldest_message = connection.lindex(channel_key, 0)
+            if oldest_message:
+                messages_age = self.expiry - connection.ttl(oldest_message)
+                statistics['messages_max_age'] = max(statistics['messages_max_age'], messages_age)
+        return statistics
+
+    def _incr_statistics_counter(self, stat_name, channel, connection):
+        """ helper function to intrement counter stats in one go """
+        self.incrstatcounters(
+            keys=[
+                "{prefix}{channel}:{stat_name}".format(
+                    prefix=self.stats_prefix,
+                    channel=channel,
+                    stat_name=stat_name,
+                ),
+                "{prefix}{global_key}:{stat_name}".format(
+                    prefix=self.stats_prefix,
+                    global_key=self.global_stats_key,
+                    stat_name=stat_name,
+                )
+            ],
+            args=[self.channel_statistics_expiry, self.global_statistics_expiry],
+            client=connection,
+        )
+
     ### Serialization ###
 
     def serialize(self, message):
@@ -349,6 +455,17 @@ class RedisChannelLayer(BaseChannelLayer):
         redis.call('expire', KEYS[1], ARGV[2])
         redis.call('rpush', KEYS[2], KEYS[1])
         redis.call('expire', KEYS[2], ARGV[2] + 1)
+    """
+
+    # Single-command to increment counter stats.
+    # Keys: channel_stat, global_stat
+    # Args: channel_stat_expiry, global_stat_expiry
+    lua_incrstatcounters = """
+        redis.call('incr', KEYS[1])
+        redis.call('expire', KEYS[1], ARGV[1])
+        redis.call('incr', KEYS[2])
+        redis.call('expire', KEYS[2], ARGV[2])
+
     """
 
     lua_lpopmany = """

--- a/asgi_redis/tests/test_core.py
+++ b/asgi_redis/tests/test_core.py
@@ -5,7 +5,6 @@ from asgi_redis import RedisChannelLayer
 from asgiref.conformance import ConformanceTestCase
 
 
-
 # Default conformance tests
 class RedisLayerTests(ConformanceTestCase):
 
@@ -40,8 +39,6 @@ class RedisLayerTests(ConformanceTestCase):
             self.channel_layer.global_statistics(),
             {
                 'messages_count': 3,
-                # 'messages_pending': 0,  #  not implemented
-                # 'messages_max_age': 0,  #  not implemented
                 'channel_full_count': 0,
             }
         )
@@ -78,8 +75,6 @@ class RedisLayerTests(ConformanceTestCase):
             self.channel_layer.global_statistics(),
             {
                 'messages_count': 6,
-                # 'messages_pending': 0,  #  not implemented
-                # 'messages_max_age': 0,  #  not implemented
                 'channel_full_count': 4,
             }
         )
@@ -112,7 +107,7 @@ class EncryptedRedisLayerTests(ConformanceTestCase):
 try:
     from twisted.internet import defer, reactor
     import twisted.trial.unittest
-    import txredisapi
+
     class TwistedTests(twisted.trial.unittest.TestCase):
 
         def setUp(self):

--- a/asgi_redis/tests/test_core.py
+++ b/asgi_redis/tests/test_core.py
@@ -31,6 +31,69 @@ class RedisLayerTests(ConformanceTestCase):
         self.assertIs(channel, None)
         self.assertIs(message, None)
 
+    def test_statistics(self):
+        self.channel_layer.send("first_channel", {"pay": "load"})
+        self.channel_layer.send("first_channel", {"pay": "load"})
+        self.channel_layer.send("second_channel", {"pay": "load"})
+
+        self.assertEqual(
+            self.channel_layer.global_statistics(),
+            {
+                'messages_count': 3,
+                # 'messages_pending': 0,  #  not implemented
+                # 'messages_max_age': 0,  #  not implemented
+                'channel_full_count': 0,
+            }
+        )
+
+        self.assertEqual(
+            self.channel_layer.channel_statistics("first_channel"),
+            {
+                'messages_count': 2,
+                'messages_pending': 2,
+                'messages_max_age': 0,
+                'channel_full_count': 0,
+            }
+        )
+
+        self.assertEqual(
+            self.channel_layer.channel_statistics("second_channel"),
+            {
+                'messages_count': 1,
+                'messages_pending': 1,
+                'messages_max_age': 0,
+                'channel_full_count': 0,
+            }
+        )
+
+        for _ in range(3):
+            self.channel_layer.send("first_channel", {"pay": "load"})
+
+        for _ in range(4):
+            with self.assertRaises(RedisChannelLayer.ChannelFull):
+                self.channel_layer.send("first_channel", {"pay": "load"})
+
+        # check that channel full exception are counted as such, not towards messages
+        self.assertEqual(
+            self.channel_layer.global_statistics(),
+            {
+                'messages_count': 6,
+                # 'messages_pending': 0,  #  not implemented
+                # 'messages_max_age': 0,  #  not implemented
+                'channel_full_count': 4,
+            }
+        )
+
+        self.assertEqual(
+            self.channel_layer.channel_statistics("first_channel"),
+            {
+                'messages_count': 5,
+                'messages_pending': 5,
+                'messages_max_age': 0,
+                'channel_full_count': 4,
+            }
+        )
+
 
 # Encrypted variant of conformance tests
 class EncryptedRedisLayerTests(ConformanceTestCase):


### PR DESCRIPTION
Basic statistics endpoints implementation, with some caveats:

- does not provide calculated per second values (these are of little use if you're sending metrics to Graphite, CloudWatch or such)
- does not provide global `messages_pending` and `messages_max_age` due performance concerns, these are still available as per channel stats