### PR TITLE
Add RedisSentinelChannelLayer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -170,6 +170,7 @@ for the RedisSentinelChannelLayer, add a list of the service names.
 Redis Sentinel mode does not support URL-style connection strings, just tuple-based ones.
 
 Configuration for Sentinel mode looks like this:
+
 .. code-block:: python
 
     CHANNEL_LAYERS = {
@@ -178,8 +179,7 @@ Configuration for Sentinel mode looks like this:
             "CONFIG": {
                 "hosts": [("10.0.0.1", 26739), ("10.0.0.2", 26379), ("10.0.0.3", 26379)],
                 "services": ["shard1", "shard2", "shard3"],
-            }
-
+            },
         },
     }
 

--- a/README.rst
+++ b/README.rst
@@ -155,6 +155,38 @@ To use it, just use the ``asgi_redis.RedisLocalChannelLayer`` class in your
 configuration instead of ``RedisChannelLayer`` and make sure you have the
 ``asgi_ipc`` package installed; no other change is needed.
 
+Sentinel Mode
+-------------
+
+"Sentinel" mode is also supported, where the Redis channel layer will connect to
+a redis sentinel cluster to find the present Redis master before writing or reading
+data.
+
+Sentinel mode supports sharding, but does not support multiple Sentinel clusters. To
+run sharding of keys across multiple Redis clusters, use a single sentinel cluster,
+but have that sentinel cluster monitor multiple "services". Then in the configuration
+for the RedisSentinelChannelLayer, add a list of the service names.
+
+Redis Sentinel mode does not support URL-style connection strings, just tuple-based ones.
+
+Configuration for Sentinel mode looks like this:
+.. code-block:: python
+
+    CHANNEL_LAYERS = {
+        "default": {
+            "BACKEND": "asgi_redis.RedisSentinelChannelLayer",
+            "CONFIG": {
+                "hosts": [("10.0.0.1", 26739), ("10.0.0.2", 26379), ("10.0.0.3", 26379)],
+                "services": ["shard1", "shard2", "shard3"],
+            }
+
+        },
+    }
+
+The "shard1", "shard2", etc entries correspond to the name of the service configured in  your
+redis `sentinel.conf` file. For example, if your `sentinel.conf` says ``sentinel monitor local 127.0.0.1 6379 1``
+then you would want to include "local" as a service in the `RedisSentinelChannelLayer` configuration.
+
 Dependencies
 ------------
 

--- a/asgi_redis/__init__.py
+++ b/asgi_redis/__init__.py
@@ -1,4 +1,5 @@
 from .core import RedisChannelLayer
 from .local import RedisLocalChannelLayer
+from .sentinel import RedisSentinelChannelLayer
 
 __version__ = '1.1.0'

--- a/asgi_redis/core.py
+++ b/asgi_redis/core.py
@@ -82,7 +82,7 @@ class RedisChannelLayer(BaseChannelLayer):
         # TODO: ensure uniqueness better, e.g. Redis keys with SETNX
         self.client_prefix = "".join(random.choice(string.ascii_letters) for i in range(8))
         self._register_scripts()
-        self._setup_enrcyption(symmetric_encryption_keys)
+        self._setup_encryption(symmetric_encryption_keys)
         self.stats_prefix = stats_prefix
 
     def _setup_hosts(self, hosts):
@@ -109,7 +109,7 @@ class RedisChannelLayer(BaseChannelLayer):
         self.delprefix = connection.register_script(self.lua_delprefix)
         self.incrstatcounters = connection.register_script(self.lua_incrstatcounters)
 
-    def _setup_enrcyption(self, symmetric_encryption_keys):
+    def _setup_encryption(self, symmetric_encryption_keys):
         # See if we can do encryption if they asked
         if symmetric_encryption_keys:
             if isinstance(symmetric_encryption_keys, six.string_types):

--- a/asgi_redis/sentinel.py
+++ b/asgi_redis/sentinel.py
@@ -3,7 +3,6 @@ from asgi_redis import RedisChannelLayer
 from redis import sentinel
 import random
 import six
-import string
 random.seed()
 
 
@@ -37,8 +36,7 @@ class RedisSentinelChannelLayer(RedisChannelLayer):
                 socket_timeout=None,
                 socket_keepalive=None,
                 socket_keepalive_options=None,
-                services=None,
-        ):
+                services=None):
             self.services = self._setup_services(services)
 
             # Precalculate some values for ring selection
@@ -67,7 +65,6 @@ class RedisSentinelChannelLayer(RedisChannelLayer):
                                                             socket_timeout,
                                                             socket_keepalive,
                                                             socket_keepalive_options)
-
 
     def _setup_services(self, services):
         final_services = list()

--- a/asgi_redis/sentinel.py
+++ b/asgi_redis/sentinel.py
@@ -53,18 +53,19 @@ class RedisSentinelChannelLayer(RedisChannelLayer):
                 },
             )
 
-            super(RedisSentinelChannelLayer, self).__init__(expiry,
-                                                            hosts,
-                                                            prefix,
-                                                            group_expiry,
-                                                            capacity,
-                                                            channel_capacity,
-                                                            symmetric_encryption_keys,
-                                                            stats_prefix,
-                                                            socket_connect_timeout,
-                                                            socket_timeout,
-                                                            socket_keepalive,
-                                                            socket_keepalive_options)
+            super(RedisSentinelChannelLayer, self).__init__(
+                expiry,
+                hosts,
+                prefix,
+                group_expiry,
+                capacity,
+                channel_capacity,
+                symmetric_encryption_keys,
+                stats_prefix,
+                socket_connect_timeout,
+                socket_timeout,
+                socket_keepalive,
+                socket_keepalive_options)
 
     def _setup_services(self, services):
         final_services = list()

--- a/asgi_redis/sentinel.py
+++ b/asgi_redis/sentinel.py
@@ -1,0 +1,208 @@
+from __future__ import unicode_literals
+from asgi_redis import RedisChannelLayer
+from redis import sentinel
+import random
+import six
+import string
+random.seed()
+
+
+class RedisSentinelChannelLayer(RedisChannelLayer):
+    """
+    Variant of the Redis channel layer that supports the Redis Sentinel HA protocol.
+
+    Supports sharding, but assumes that there is only one sentinel cluster with multiple redis services
+    monitored by that cluster. So, this will only connect to a single cluster of Sentinel servers,
+    but will suppport sharding by asking that sentinel cluster for different services. Also, any redis connection
+    options (socket timeout, socket keepalive, etc) will be assumed to be identical across redis server, and
+    across all services.
+
+    "hosts" in this arrangement, is used to list the redis sentinel hosts. As such, it only supports the
+    tuple method of specifying hosts, as that's all the redis sentinel python library supports at the moment.
+
+    "services" is the list of redis services monitored by the sentinel system that redis keys will be distributed
+     across.
+    """
+    def __init__(
+                self,
+                expiry=60,
+                hosts=None,
+                prefix="asgi:",
+                group_expiry=86400,
+                capacity=100,
+                channel_capacity=None,
+                symmetric_encryption_keys=None,
+                stats_prefix="asgi-meta:",
+                socket_connect_timeout=None,
+                socket_timeout=None,
+                socket_keepalive=None,
+                socket_keepalive_options=None,
+                services=None,
+        ):
+            super(RedisChannelLayer, self).__init__(
+                expiry=expiry,
+                group_expiry=group_expiry,
+                capacity=capacity,
+                channel_capacity=channel_capacity,
+            )
+            # Make sure they provided some hosts, or provide a default
+            if not hosts:
+                hosts = [("localhost", 26379)]
+            self.hosts = list()
+            self.services = list()
+
+            if not services:
+                raise ValueError("Must specify at least one service name monitored by Sentinel")
+
+            if isinstance(services, six.string_types):
+                raise ValueError("Sentinel service types must be specified as an iterable list of strings")
+
+            for entry in services:
+                if not isinstance(entry, six.string_types):
+                    raise ValueError("Sentinel service types must be specified as strings.")
+                else:
+                    self.services.append(entry)
+
+            if isinstance(hosts, six.string_types):
+                # user accidentally used one host string instead of providing a list of hosts
+                raise ValueError('ASGI Redis hosts must be specified as an iterable list of hosts.')
+
+            for entry in hosts:
+                if isinstance(entry, six.string_types):
+                    raise ValueError("Sentinel Redis host entries must be specified as tuples, not strings.")
+                else:
+                    self.hosts.append(entry)
+            self.prefix = prefix
+            assert isinstance(self.prefix, six.text_type), "Prefix must be unicode"
+            # Precalculate some values for ring selection
+            self.ring_size = len(self.services)
+            # Create connections ahead of time (they won't call out just yet, but
+            # we want to connection-pool them later)
+            if socket_timeout and socket_timeout < self.blpop_timeout:
+                raise ValueError("The socket timeout must be at least %s seconds" % self.blpop_timeout)
+            self._sentinel = self._generate_sentinel(
+                redis_kwargs={
+                    "socket_connect_timeout": socket_connect_timeout,
+                    "socket_timeout": socket_timeout,
+                    "socket_keepalive": socket_keepalive,
+                    "socket_keepalive_options": socket_keepalive_options,
+                },
+            )
+            # Decide on a unique client prefix to use in ! sections
+            # TODO: ensure uniqueness better, e.g. Redis keys with SETNX
+            self.client_prefix = "".join(random.choice(string.ascii_letters) for i in range(8))
+            # Register scripts
+            connection = self.connection(None)
+            self.chansend = connection.register_script(self.lua_chansend)
+            self.lpopmany = connection.register_script(self.lua_lpopmany)
+            self.delprefix = connection.register_script(self.lua_delprefix)
+            self.incrstatcounters = connection.register_script(self.lua_incrstatcounters)
+            # See if we can do encryption if they asked
+            if symmetric_encryption_keys:
+                if isinstance(symmetric_encryption_keys, six.string_types):
+                    raise ValueError("symmetric_encryption_keys must be a list of possible keys")
+                try:
+                    from cryptography.fernet import MultiFernet
+                except ImportError:
+                    raise ValueError("Cannot run with encryption without 'cryptography' installed.")
+                sub_fernets = [self.make_fernet(key) for key in symmetric_encryption_keys]
+                self.crypter = MultiFernet(sub_fernets)
+            else:
+                self.crypter = None
+            self.stats_prefix = stats_prefix
+
+    def _generate_sentinel(self, redis_kwargs):
+        # pass redis_kwargs through to the sentinel object to be used for each connection to the redis servers.
+        return sentinel.Sentinel(self.hosts, **redis_kwargs)
+
+    def flush(self):
+        """
+        Deletes all messages and groups on all shards.
+        """
+        for service_name in self.services:
+            connection = self._sentinel.master_for(service_name)
+            self.delprefix(keys=[], args=[self.prefix + "*"], client=connection)
+            self.delprefix(keys=[], args=[self.stats_prefix + "*"], client=connection)
+
+    def connection(self, index):
+        # return the master for the given index
+        # If index is explicitly None, pick a random server
+        if index is None:
+            index = self.random_index()
+        # Catch bad indexes
+        if not 0 <= index < self.ring_size:
+            raise ValueError("There are only %s hosts - you asked for %s!" % (self.ring_size, index))
+        service_name = self.services[index]
+        return self._sentinel.master_for(service_name)
+
+    def random_index(self):
+        return random.randint(0, len(self.services) - 1)
+
+    def global_statistics(self):
+        """
+        Returns dictionary of statistics across all channels on all shards.
+        Return value is a dictionary with following fields:
+            * messages_count, the number of messages processed since server start
+            * channel_full_count, the number of times ChannelFull exception has been risen since server start
+
+        This implementation does not provide calculated per second values.
+        Due perfomance concerns, does not provide aggregated messages_pending and messages_max_age,
+        these are only avaliable per channel.
+
+        """
+        statistics = {
+            self.STAT_MESSAGES_COUNT: 0,
+            self.STAT_CHANNEL_FULL: 0,
+        }
+        prefix = self.stats_prefix + self.global_stats_key
+        for service_name in self.services:
+            connection = self._sentinel.master_for(service_name)
+            messages_count, channel_full_count = connection.mget(
+                ':'.join((prefix, self.STAT_MESSAGES_COUNT)),
+                ':'.join((prefix, self.STAT_CHANNEL_FULL)),
+            )
+            statistics[self.STAT_MESSAGES_COUNT] += int(messages_count or 0)
+            statistics[self.STAT_CHANNEL_FULL] += int(channel_full_count or 0)
+
+        return statistics
+
+    def channel_statistics(self, channel):
+        """
+        Returns dictionary of statistics for specified channel.
+        Return value is a dictionary with following fields:
+            * messages_count, the number of messages processed since server start
+            * messages_pending, the current number of messages waiting
+            * messages_max_age, how long the oldest message has been waiting, in seconds
+            * channel_full_count, the number of times ChannelFull exception has been risen since server start
+
+        This implementation does not provide calculated per second values
+        """
+        statistics = {
+            self.STAT_MESSAGES_COUNT: 0,
+            self.STAT_MESSAGES_PENDING: 0,
+            self.STAT_MESSAGES_MAX_AGE: 0,
+            self.STAT_CHANNEL_FULL: 0,
+        }
+        prefix = self.stats_prefix + channel
+
+        if "!" in channel or "?" in channel:
+            connections = [self.connection(self.consistent_hash(channel))]
+        else:
+            # if we don't know where it is, we have to check in all shards
+            connections = [self._sentinel.master_for(service_name) for service_name in self.services]
+
+        channel_key = self.prefix + channel
+
+        for connection in connections:
+            messages_count, channel_full_count = connection.mget(
+                ':'.join((prefix, self.STAT_MESSAGES_COUNT)),
+                ':'.join((prefix, self.STAT_CHANNEL_FULL)),
+            )
+            statistics[self.STAT_MESSAGES_COUNT] += int(messages_count or 0)
+            statistics[self.STAT_CHANNEL_FULL] += int(channel_full_count or 0)
+            statistics[self.STAT_MESSAGES_PENDING] += connection.llen(channel_key)
+            oldest_message = connection.lindex(channel_key, 0)
+            if oldest_message:
+                messages_age = self.expiry - connection.ttl(oldest_message)
+                statistics[self.STAT_MESSAGES_MAX_AGE] = max(statistics[self.STAT_MESSAGES_MAX_AGE], messages_age)
+        return statistics

--- a/asgi_redis/tests/sentinel.conf
+++ b/asgi_redis/tests/sentinel.conf
@@ -2,4 +2,4 @@
 bind 127.0.0.1
 port 26379
 sentinel monitor local 127.0.0.1 6379 1
-sentinel config-epoch local 1
+

--- a/asgi_redis/tests/sentinel.conf
+++ b/asgi_redis/tests/sentinel.conf
@@ -2,4 +2,3 @@
 bind 127.0.0.1
 port 26379
 sentinel monitor local 127.0.0.1 6379 1
-

--- a/asgi_redis/tests/sentinel.conf
+++ b/asgi_redis/tests/sentinel.conf
@@ -1,0 +1,6 @@
+# example sentinel config for use while running tox tests.
+bind 127.0.0.1
+port 26379
+sentinel myid 2ec261d13b57d1b1000e3c0fc7dc4544095232ec
+sentinel monitor local 127.0.0.1 6379 1
+sentinel config-epoch local 1

--- a/asgi_redis/tests/sentinel.conf
+++ b/asgi_redis/tests/sentinel.conf
@@ -1,6 +1,5 @@
 # example sentinel config for use while running tox tests.
 bind 127.0.0.1
 port 26379
-sentinel myid 2ec261d13b57d1b1000e3c0fc7dc4544095232ec
 sentinel monitor local 127.0.0.1 6379 1
 sentinel config-epoch local 1

--- a/asgi_redis/tests/test_sentinel.py
+++ b/asgi_redis/tests/test_sentinel.py
@@ -1,0 +1,104 @@
+from __future__ import unicode_literals
+import time
+import unittest
+from asgi_redis import RedisSentinelChannelLayer
+from asgiref.conformance import ConformanceTestCase
+
+
+# Default conformance tests
+class RedisLayerTests(ConformanceTestCase):
+
+    channel_layer = RedisSentinelChannelLayer(expiry=1, group_expiry=2, capacity=5, services=['local'])
+    expiry_delay = 1.1
+    capacity_limit = 5
+
+    # The functionality this test is for is not yet present (it's not required,
+    # and will slow stuff down, so will be optional), but it's here for future reference.
+    @unittest.expectedFailure
+    def test_group_message_eviction(self):
+        """
+        Tests that when messages expire, group expiry also occurs.
+        """
+        # Add things to a group and send a message that should expire
+        self.channel_layer.group_add("tgme_group", "tgme_test")
+        self.channel_layer.send_group("tgme_group", {"value": "blue"})
+        # Wait message expiry plus a tiny bit (must sum to less than group expiry)
+        time.sleep(1.2)
+        # Send new message to group, ensure message never arrives
+        self.channel_layer.send_group("tgme_group", {"value": "blue"})
+        channel, message = self.channel_layer.receive(["tgme_test"])
+        self.assertIs(channel, None)
+        self.assertIs(message, None)
+
+    def test_statistics(self):
+        self.channel_layer.send("first_channel", {"pay": "load"})
+        self.channel_layer.send("first_channel", {"pay": "load"})
+        self.channel_layer.send("second_channel", {"pay": "load"})
+
+        self.assertEqual(
+            self.channel_layer.global_statistics(),
+            {
+                'messages_count': 3,
+                'channel_full_count': 0,
+            }
+        )
+
+        self.assertEqual(
+            self.channel_layer.channel_statistics("first_channel"),
+            {
+                'messages_count': 2,
+                'messages_pending': 2,
+                'messages_max_age': 0,
+                'channel_full_count': 0,
+            }
+        )
+
+        self.assertEqual(
+            self.channel_layer.channel_statistics("second_channel"),
+            {
+                'messages_count': 1,
+                'messages_pending': 1,
+                'messages_max_age': 0,
+                'channel_full_count': 0,
+            }
+        )
+
+        for _ in range(3):
+            self.channel_layer.send("first_channel", {"pay": "load"})
+
+        for _ in range(4):
+            with self.assertRaises(RedisSentinelChannelLayer.ChannelFull):
+                self.channel_layer.send("first_channel", {"pay": "load"})
+
+        # check that channel full exception are counted as such, not towards messages
+        self.assertEqual(
+            self.channel_layer.global_statistics(),
+            {
+                'messages_count': 6,
+                'channel_full_count': 4,
+            }
+        )
+
+        self.assertEqual(
+            self.channel_layer.channel_statistics("first_channel"),
+            {
+                'messages_count': 5,
+                'messages_pending': 5,
+                'messages_max_age': 0,
+                'channel_full_count': 4,
+            }
+        )
+
+
+# Encrypted variant of conformance tests
+class EncryptedRedisLayerTests(ConformanceTestCase):
+
+    channel_layer = RedisSentinelChannelLayer(
+        expiry=1,
+        group_expiry=2,
+        capacity=5,
+        symmetric_encryption_keys=["test", "old"],
+        services=['local']
+    )
+    expiry_delay = 1.1
+    capacity_limit = 5


### PR DESCRIPTION
Adds a new Channel Layer: `RedisSentinelChannelLayer`.

A few notes on this: 
 * it only supports one sentinel cluster, so sharding is supported by having the sentinel cluster monitor multiple services, and specifying those services in the `CHANNEL_LAYERS` setting.
 * At least one service has to be specified in order to have something to ask the sentinel servers for.
 * The default redis sentinel object doesn't seem to support URL-format server specifications configuration, just tuple-format. So, the sentinel channel layer doesn't support URL-format either.
 * the "hosts" config setting in Sentinel format is the list of Sentinel servers, not redis servers.