### PR TITLE
fix: assert '__asgi_channel__' not in message

### DIFF
--- a/asgi_redis/core.py
+++ b/asgi_redis/core.py
@@ -329,7 +329,7 @@ class RedisChannelLayer(BaseChannelLayer):
         # TODO: More efficient implementation (lua script per shard?)
         for channel in self.group_channels(group):
             try:
-                self.send(channel, message)
+                self.send(channel, dict(**message))
             except self.ChannelFull:
                 pass
 


### PR DESCRIPTION
When using django-channels and sending message to multiple channels, the
message is modified by `send` and breaks when it's used again by the
next `send`.

```
18:07:54 worker.1 | Traceback (most recent call last):
18:07:54 worker.1 |   File "manage.py", line 10, in <module>
18:07:54 worker.1 |     execute_from_command_line(sys.argv)
18:07:54 worker.1 |   File "/home/yoan/work/hearc/webappII/tsuro/lib/python3.6/site-packages/django/core/management/__init__.py", line 367, in execute_from_command_line
18:07:54 worker.1 |     utility.execute()
18:07:54 worker.1 |   File "/home/yoan/work/hearc/webappII/tsuro/lib/python3.6/site-packages/django/core/management/__init__.py", line 359, in execute
18:07:54 worker.1 |     self.fetch_command(subcommand).run_from_argv(self.argv)
18:07:54 worker.1 |   File "/home/yoan/work/hearc/webappII/tsuro/lib/python3.6/site-packages/django/core/management/base.py", line 294, in run_from_argv
18:07:54 worker.1 |     self.execute(*args, **cmd_options)
18:07:54 worker.1 |   File "/home/yoan/work/hearc/webappII/tsuro/lib/python3.6/site-packages/django/core/management/base.py", line 345, in execute
18:07:54 worker.1 |     output = self.handle(*args, **options)
18:07:54 worker.1 |   File "/home/yoan/work/hearc/webappII/tsuro/lib/python3.6/site-packages/channels/management/commands/runworker.py", line 83, in handle
18:07:54 worker.1 |     worker.run()
18:07:54 worker.1 |   File "/home/yoan/work/hearc/webappII/tsuro/lib/python3.6/site-packages/channels/worker.py", line 163, in run
18:07:54 worker.1 |     consumer_finished.send(sender=self.__class__)
18:07:54 worker.1 |   File "/home/yoan/work/hearc/webappII/tsuro/lib/python3.6/site-packages/django/dispatch/dispatcher.py", line 191, in send
18:07:54 worker.1 |     response = receiver(signal=self, sender=sender, **named)
18:07:54 worker.1 |   File "/home/yoan/work/hearc/webappII/tsuro/lib/python3.6/site-packages/channels/message.py", line 90, in send_and_flush
18:07:54 worker.1 |     sender.send(message, immediately=True)
18:07:54 worker.1 |   File "/home/yoan/work/hearc/webappII/tsuro/lib/python3.6/site-packages/channels/channel.py", line 88, in send
18:07:54 worker.1 |     self.channel_layer.send_group(self.name, content)
18:07:54 worker.1 |   File "/home/yoan/work/hearc/webappII/tsuro/lib/python3.6/site-packages/asgi_redis/core.py", line 336, in send_group
18:07:54 worker.1 |     self.send(channel, message)
18:07:54 worker.1 |   File "/home/yoan/work/hearc/webappII/tsuro/lib/python3.6/site-packages/asgi_redis/core.py", line 153, in send
18:07:54 worker.1 |     assert "__asgi_channel__" not in message
18:07:54 worker.1 | AssertionError
```

- asgi-redis==1.2.0
- asgiref==1.1.0
- channels==1.1.2