### PR TITLE
Do not loop forever on receive with block=True

### DIFF
--- a/asgi_redis/core.py
+++ b/asgi_redis/core.py
@@ -207,10 +207,7 @@ class RedisChannelLayer(BaseChannelLayer):
                 connection = self.connection(index)
                 # Pop off any waiting message
                 if block:
-                    try:
-                        result = connection.blpop(list_names, timeout=self.blpop_timeout)
-                    except redis.exceptions.TimeoutError:
-                        continue
+                    result = connection.blpop(list_names, timeout=self.blpop_timeout)
                 else:
                     result = self.lpopmany(keys=list_names, client=connection)
                 if result:
@@ -229,7 +226,7 @@ class RedisChannelLayer(BaseChannelLayer):
                         del message['__asgi_channel__']
                     return channel, message
             # If we only got expired content, try again
-            if block or got_expired_content:
+            if got_expired_content:
                 continue
             else:
                 return None, None


### PR DESCRIPTION
I made an obvious oversight when writing this: the current code changed the meaning of `block` from "block until each connection times out" to "block forever". Mea culpa.

Also, there's no reason to try/except around `connection.blpop` because it will never raise a `TimeoutError`, only return `None` if it times out.