### PR TITLE
Precalculate Script.sha when creating scripts

### DIFF
--- a/asgi_redis/core.py
+++ b/asgi_redis/core.py
@@ -3,14 +3,15 @@ from __future__ import unicode_literals
 import base64
 import binascii
 import hashlib
+import itertools
 import msgpack
 import random
 import redis
+from redis._compat import b
 import six
 import string
 import time
 import uuid
-import itertools
 
 try:
     import txredisapi
@@ -107,6 +108,10 @@ class RedisChannelLayer(BaseChannelLayer):
         self.lpopmany = connection.register_script(self.lua_lpopmany)
         self.delprefix = connection.register_script(self.lua_delprefix)
         self.incrstatcounters = connection.register_script(self.lua_incrstatcounters)
+        self.chansend.sha = hashlib.sha1(b(self.chansend.script)).hexdigest()
+        self.lpopmany.sha = hashlib.sha1(b(self.lpopmany.script)).hexdigest()
+        self.delprefix.sha = hashlib.sha1(b(self.delprefix.script)).hexdigest()
+        self.incrstatcounters.sha = hashlib.sha1(b(self.incrstatcounters.script)).hexdigest()
 
     def _setup_encryption(self, symmetric_encryption_keys):
         # See if we can do encryption if they asked

--- a/asgi_redis/core.py
+++ b/asgi_redis/core.py
@@ -207,10 +207,7 @@ class RedisChannelLayer(BaseChannelLayer):
                 connection = self.connection(index)
                 # Pop off any waiting message
                 if block:
-                    try:
-                        result = connection.blpop(list_names, timeout=self.blpop_timeout)
-                    except redis.exceptions.TimeoutError:
-                        continue
+                    result = connection.blpop(list_names, timeout=self.blpop_timeout)
                 else:
                     result = self.lpopmany(keys=list_names, client=connection)
                 if result:
@@ -229,7 +226,7 @@ class RedisChannelLayer(BaseChannelLayer):
                         del message['__asgi_channel__']
                     return channel, message
             # If we only got expired content, try again
-            if block or got_expired_content:
+            if got_expired_content:
                 continue
             else:
                 return None, None

--- a/asgi_redis/sentinel.py
+++ b/asgi_redis/sentinel.py
@@ -1,12 +1,16 @@
 from __future__ import unicode_literals
-from asgi_redis import RedisChannelLayer
+
+import hashlib
+import itertools
+import random
 import redis
 from redis.sentinel import Sentinel
 from redis.client import Script
-import random
+from redis._compat import b
 import six
 import time
-import itertools
+
+from asgi_redis import RedisChannelLayer
 
 random.seed()
 
@@ -79,6 +83,10 @@ class RedisSentinelChannelLayer(RedisChannelLayer):
         self.lpopmany = Script(None, self.lua_lpopmany)
         self.delprefix = Script(None, self.lua_delprefix)
         self.incrstatcounters = Script(None, self.lua_incrstatcounters)
+        self.chansend.sha = hashlib.sha1(b(self.chansend.script)).hexdigest()
+        self.lpopmany.sha = hashlib.sha1(b(self.lpopmany.script)).hexdigest()
+        self.delprefix.sha = hashlib.sha1(b(self.delprefix.script)).hexdigest()
+        self.incrstatcounters.sha = hashlib.sha1(b(self.incrstatcounters.script)).hexdigest()
 
     def _validate_service_names(self, services):
         if isinstance(services, six.string_types):


### PR DESCRIPTION
This is a workaround for the problem described in [this PR](https://github.com/andymccurdy/redis-py/pull/867) for `redis-py`.

In short, `Script` objects are initialized with `sha` set to the empty string, which means that the first time the `Script` is executed, it makes an `EVALSHA` call that is guaranteed to fail. This produces extra traffic for no apparent benefit.

The above PR is the preferred fix, but this will do the job until that is resolved.