### PR TITLE
Factor out common functionality from Redis and Sentinel channel layers into base class

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM ubuntu:16.04
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
     apt-get -yqq install \
+    git \
     build-essential python-pip software-properties-common \
     python-dev python3-dev \
     libffi-dev libxml2-dev libxslt-dev libssl-dev

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     include_package_data=True,
     install_requires=[
         'six',
-        'redis>=2.10',
+        'redis~=2.10.6',
         'msgpack-python',
         'asgiref~=1.1.2',
     ],

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,6 +1,8 @@
+import os
 import subprocess
 import sys
 import time
+import unittest
 
 import benchmark
 import requests
@@ -8,6 +10,7 @@ import websocket
 from channels.test import ChannelLiveServerTestCase
 
 
+@unittest.skipIf(os.environ.get("DOCKER_TEST_ENV"), "Skipping integration tests in Docker")
 class IntegrationTest(ChannelLiveServerTestCase):
 
     def test_http_request(self):
@@ -43,6 +46,7 @@ class IntegrationTest(ChannelLiveServerTestCase):
         assert proc.returncode == 0
 
 
+@unittest.skipIf(os.environ.get("DOCKER_TEST_ENV"), "Skipping integration tests in Docker")
 class ConcurrentIntegrationTest(IntegrationTest):
 
     worker_threads = 4


### PR DESCRIPTION
### Summary

Since `RedisSentinelChannelLayer` performs a fundamentally different setup routine than `RedisChannelLayer` does, it does not make sense for the former to inherit from the latter. The previous implementation was clunky and limiting, so I moved the common methods and setup steps into `BaseRedisChannelLayer`, and made `RedisSentinelChannelLayer` and `RedisChannelLayer` inherit from it.

### Bug fixes
- The original motivation for this work was to fix a bug introduced by [this commit](https://github.com/andymccurdy/redis-py/commit/29a7ecebd0f4709fc184c6af57c6eb1a59cb071e#diff-085cbe85ef9bc2ad832d79163eb39172) in `redis-py`, which was included in the 2.10.6 patch version. I updated the channel layer script initialization to work with this version of Redis. This required moving script initialization to the end of the `__init__` method of `RedisSentinelChannelLayer`, which prompted the refactor in the first place.
-  [This commit](https://github.com/django/asgi_redis/commit/984b5be51e7aba6144f9e99bcdc90139c10454d4) introduced a `git` requirement for tests, so I added that to the `Dockerfile`. The integration tests included in that commit also break in Docker, because they rely on settings from another repository that point to the default address for Redis. I made sure those tests are skipped in Docker.